### PR TITLE
Update departures.xml

### DIFF
--- a/locales/departures.xml
+++ b/locales/departures.xml
@@ -10,7 +10,7 @@
 
 	Supported operators:
 	* AT: ÖBB
-	* BE: De Lijn
+	* BE: De Lijn, TEC (SRWT)
 	* DE: Deutsche Bahn, Verkehrsverbund Stuttgart, Stadtwerke Neuss, Stadtbus Eschwege, Nordhessischer Verkehrsverbund, Braunschweiger Verkehrs AG
 	* ES: Titsa
 	* IT: ATAC, AMT Genova
@@ -24,16 +24,34 @@
 			<match mode="or">
 				<tag k="highway" v="bus_stop"/>
 		 		<tag k="public_transport" v="platform"/>
-				<tag k="public_transport" v="stop_position"/>
 			</match>
 			<tag k="operator" v="(.*;|^)De Lijn(;.*|$)"/>
 		</match>
 		<find>
-			<tag k="ref" v="([0-9]*)" match_id="stop_ref"/>
+			<tag k="ref:De_Lijn" v="([0-9]*)" match_id="stop_ref"/>
 		</find>
 		<output>
 			<copy-all/>
 			<tag from_match="stop_ref" k="departures" v="http://mijnlijn.be/{0}"/>
+		</output>
+	</translation>
+	<translation>
+		<name>TEC</name>
+		<description>Timetables for public transport stops operated by "TEC" in Brabant Wallon, Belgium.</description>
+		<match mode="and">
+			<match mode="or">
+				<tag k="highway" v="bus_stop"/>
+		 		<tag k="public_transport" v="platform"/>
+			</match>
+			<tag k="operator" v="(.*;|^)TEC[BCHNLX](;.*|$)"/>
+			<match mode="or">
+				<tag k="name:TEC" v="(.*)" match_id="stop_name"/>
+				<tag k="name" v="(.*)" match_id="stop_name"/>
+			</match>
+		</match>
+		<output>
+			<copy-all/>
+			<tag from_match="stop_name" k="departures" v="http://www.infotec.be/fr-be/medeplacer/horaires/arret?arret={0}"/>
 		</output>
 	</translation>
 	<translation>

--- a/locales/departures.xml
+++ b/locales/departures.xml
@@ -25,11 +25,8 @@
 				<tag k="highway" v="bus_stop"/>
 		 		<tag k="public_transport" v="platform"/>
 			</match>
-			<tag k="operator" v="(.*;|^)De Lijn(;.*|$)"/>
-		</match>
-		<find>
 			<tag k="ref:De_Lijn" v="([0-9]*)" match_id="stop_ref"/>
-		</find>
+		</match>
 		<output>
 			<copy-all/>
 			<tag from_match="stop_ref" k="departures" v="http://mijnlijn.be/{0}"/>


### PR DESCRIPTION
De Lijn now has its ref in ref:De_Lijn
TEC also has real time information, but they look up based on the stop name. This is awkward as we couldn't always use the names they provided. They have been normalised to expand abbreviations or to (re)add accented characters. We can put their exact names in name:TEC. Is their a way to 'coalesce'. Use name only if name:TEC doesn't exist?